### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/widerface_evaluate/evaluation.py
+++ b/widerface_evaluate/evaluation.py
@@ -91,7 +91,7 @@ def read_pred_file(filepath):
     boxes = []
     for line in lines:
         line = line.rstrip('\r\n').split(' ')
-        if line[0] is '':
+        if line[0] == '':
             continue
         # a = float(line[4])
         boxes.append([float(line[0]), float(line[1]), float(line[2]), float(line[3]), float(line[4])])


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8  Detected in #64